### PR TITLE
bugfix: call logout() on exit

### DIFF
--- a/check_xenserver.py
+++ b/check_xenserver.py
@@ -45,7 +45,8 @@ def logout():
         session.xenapi.session.logout()
     except:
         pass
-    atexit.register(logout)
+
+atexit.register(logout)
 
 def humanize_bytes(bytes, precision=2, suffix=True, format="pnp4nagios"):
 


### PR DESCRIPTION
Indentation was bad and atexit.register(logout) was never called (it was inside the logout() function)