### PR TITLE
Specify options from the cli (get rid of config.ini file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,14 @@ nagios-xenserver
 Nagios check plugin for xenserver
 ---------------------------------
 
-	Usage: ./check_xenserver.py <pool_name> <config_file> <check_{sr,mem,cpu,hosts}> [warning level %] [critical level %]
+	Usage: ./check_xenserver.py hostname username password <check_{sr,mem,cpu,hosts}> [warning level %] [critical level %]
 see online help for more informations
 
-Config file follows ini format. In the [general] section, define the performance data format : can be "pnp4nagios" or other.
-The name of the other sections are references, mandatory fields are :
- - host: ip or name of the pool master
- - username
- - password
- - exclude_SRs: <list of SRs you want to exclude>
-
-Example :
-```
-[general]
-perfdata_format: pnp4nagios
-
-[Production1]
-host: xenserver-prod01.servers.domain.com
-username: nagios
-password: nagios
-exclude_srs: SR1, SR2
-
-[Dev]
-host: 192.168.0.1
-username: nagios
-password: nagios
-```	
- - Uses https to connect to XenServer, if you have a pool, use a poolmaster IP/FQDN
+ - Uses https by default to connect to XenServer, if you have a pool, use a poolmaster IP/FQDN
  - Uses (python) XenAPI, download it from XenServer http://www.xenserver.org/partners/developing-products-for-xenserver.html and parse_rrd
 
 Credit for most of the code goes to ppanula, check http://exchange.nagios.org/directory/Plugins/System-Metrics/Storage-Subsystem/check_sr-2Epy/details for original code
 
-Dated: 03/05/2014
-Version: 1.3
 
 Version history:
 ----------------

--- a/config.ini
+++ b/config.ini
@@ -1,8 +1,0 @@
-[10.0.0.1]
-username: toto
-password: nagios
-protocol: http
-[192.168.124.129]
-username: root
-password: root
-protocol: https


### PR DESCRIPTION
Hello,

For doing checks from monitoring tools such as nagios/shinken/icinga/... I find it more simple to have no specific config file for the check tool, to specify all arguments from the command line (it allows me to keep all configuration in the configuration of monitoring tool).

This PR implements this from your code. It suppresses the 'config file' option, so it changes the behaviour of the tool.

Note : another PR should come soon, with ability to check VM resources (CPU and RAM).